### PR TITLE
refactor: shared pointers removed from trivial places, replaced by unique and raw pointers

### DIFF
--- a/Source/Application.cpp
+++ b/Source/Application.cpp
@@ -17,18 +17,16 @@ constexpr int FRAMES_BUFFER = 50;
 Application::Application()
 {
 	// Order matters: they will Init/start/update in this order
-	modules.push_back(window = std::make_shared<ModuleWindow>());
-	modules.push_back(editor = std::make_shared<ModuleEditor>());
-	modules.push_back(input = std::make_shared<ModuleInput>());
-	modules.push_back(program = std::make_shared<ModuleProgram>()); 
-	modules.push_back(fileSystem = std::make_shared<ModuleFileSystem>());
-	modules.push_back(resources = std::make_shared<ModuleResources>());
-	modules.push_back(engineCamera = std::make_shared<ModuleEngineCamera>());
-	modules.push_back(scene = std::make_shared<ModuleScene>());
-	modules.push_back(renderer = std::make_shared<ModuleRender>());
-	modules.push_back(debug = std::make_shared<ModuleDebugDraw>());
-
-
+	modules.push_back(std::unique_ptr<ModuleWindow>(window = new ModuleWindow()));
+	modules.push_back(std::unique_ptr<ModuleEditor>(editor = new ModuleEditor()));
+	modules.push_back(std::unique_ptr<ModuleInput>(input = new ModuleInput()));
+	modules.push_back(std::unique_ptr<ModuleProgram>(program = new ModuleProgram()));
+	modules.push_back(std::unique_ptr<ModuleFileSystem>(fileSystem = new ModuleFileSystem()));
+	modules.push_back(std::unique_ptr<ModuleResources>(resources = new ModuleResources()));
+	modules.push_back(std::unique_ptr<ModuleEngineCamera>(engineCamera = new ModuleEngineCamera()));
+	modules.push_back(std::unique_ptr<ModuleScene>(scene = new ModuleScene()));
+	modules.push_back(std::unique_ptr<ModuleRender>(renderer = new ModuleRender()));
+	modules.push_back(std::unique_ptr<ModuleDebugDraw>(debug = new ModuleDebugDraw()));
 
 	appTimer = std::make_unique<Timer>();
 	maxFramerate = MAX_FRAMERATE;

--- a/Source/Application.h
+++ b/Source/Application.h
@@ -32,18 +32,18 @@ public:
 	float GetDeltaTime() const;
 
 public:
-	std::shared_ptr<ModuleScene> scene;
-	std::shared_ptr<ModuleFileSystem> fileSystem;
-	std::shared_ptr<ModuleRender> renderer;
-	std::shared_ptr<ModuleWindow> window;
-	std::shared_ptr<ModuleInput> input;
-	std::shared_ptr<ModuleProgram> program;
-	std::shared_ptr<ModuleDebugDraw> debug;
-	std::shared_ptr<ModuleEditor> editor;
-	std::shared_ptr<ModuleEngineCamera> engineCamera;
-	std::shared_ptr<ModuleResources> resources;
+	ModuleScene* scene;
+	ModuleFileSystem* fileSystem;
+	ModuleRender* renderer;
+	ModuleWindow* window;
+	ModuleInput* input;
+	ModuleProgram* program;
+	ModuleDebugDraw* debug;
+	ModuleEditor* editor;
+	ModuleEngineCamera* engineCamera;
+	ModuleResources* resources;
 private:
-	std::vector<std::shared_ptr<Module> > modules;
+	std::vector<std::unique_ptr<Module> > modules;
 	std::unique_ptr<Timer> appTimer;
 
 	int maxFramerate;

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMaterialInput.cpp
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMaterialInput.cpp
@@ -5,14 +5,23 @@
 #include "Resources/ResourceMaterial.h"
 #include "Components/ComponentMaterial.h"
 
+WindowMaterialInput::WindowMaterialInput(ComponentMaterial* componentMaterial) :
+	WindowFileBrowser(),
+	componentMaterial(componentMaterial)
+{
+	dialogName = "Select Material";
+	title = "Load Material";
+	filters = MATERIAL_EXTENSION;
+	startPath = "Assets/Materials";
+}
+
 void WindowMaterialInput::DoThisIfOk()
 {
-	std::shared_ptr<ComponentMaterial> asShared = componentMaterial.lock();
-	if (asShared)
+	if (componentMaterial)
 	{
 		std::string filePath = std::string(fileDialogImporter.GetFilePathName());
 		UID uidMaterial = App->resources->ImportResource(filePath);
 		std::weak_ptr<ResourceMaterial> material = App->resources->RequestResource<ResourceMaterial>(uidMaterial);
-		asShared->SetMaterial(material);
+		componentMaterial->SetMaterial(material);
 	}
 }

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMaterialInput.h
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMaterialInput.h
@@ -7,22 +7,12 @@ class ComponentMaterial;
 class WindowMaterialInput : public WindowFileBrowser
 {
 public:
-	WindowMaterialInput(const std::weak_ptr<ComponentMaterial>& componentMaterial);
+	WindowMaterialInput(ComponentMaterial* componentMaterial);
 	~WindowMaterialInput() = default;
 	void DoThisIfOk() override;
 
 private:
-	std::weak_ptr<ComponentMaterial> componentMaterial;
+	ComponentMaterial* componentMaterial;
 
 	friend class WindowComponentMaterial;
 };
-
-inline WindowMaterialInput::WindowMaterialInput(const std::weak_ptr<ComponentMaterial>& componentMaterial) :
-	WindowFileBrowser(),
-	componentMaterial(componentMaterial)
-{
-	dialogName = "Select Material";
-	title = "Load Material";
-	filters = MATERIAL_EXTENSION;
-	startPath = "Assets/Materials";
-}

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMeshInput.cpp
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMeshInput.cpp
@@ -5,14 +5,23 @@
 #include "FileSystem/ModuleResources.h"
 #include "Resources/ResourceMesh.h"
 
+WindowMeshInput::WindowMeshInput(ComponentMeshRenderer* componentMesh) :
+	WindowFileBrowser(),
+	componentMesh(componentMesh)
+{
+	dialogName = "Select Mesh";
+	title = "Load Mesh";
+	filters = MESH_EXTENSION;
+	startPath = "Assets/Meshes";
+}
+
 void WindowMeshInput::DoThisIfOk()
 {
-	std::shared_ptr<ComponentMeshRenderer> asShared = componentMesh.lock();
-	if (asShared)
+	if (componentMesh)
 	{
 		std::string filePath = std::string(fileDialogImporter.GetFilePathName());
 		UID uidMesh = App->resources->ImportResource(filePath);
 		std::weak_ptr<ResourceMesh> mesh = App->resources->RequestResource<ResourceMesh>(uidMesh);
-		asShared->SetMesh(mesh);
+		componentMesh->SetMesh(mesh);
 	}
 }

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMeshInput.h
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowMeshInput.h
@@ -9,21 +9,10 @@ class WindowMeshInput :
 	public WindowFileBrowser
 {
 public:
-	WindowMeshInput(const std::weak_ptr<ComponentMeshRenderer>& componentMesh);
+	WindowMeshInput(ComponentMeshRenderer* componentMesh);
 	~WindowMeshInput() = default;
 	void DoThisIfOk() override;
 
 private:
-	std::weak_ptr<ComponentMeshRenderer> componentMesh;
+	ComponentMeshRenderer* componentMesh;
 };
-
-inline WindowMeshInput::WindowMeshInput(const std::weak_ptr<ComponentMeshRenderer>& componentMesh) :
-	WindowFileBrowser(),
-	componentMesh(componentMesh)
-{
-	dialogName = "Select Mesh";
-	title = "Load Mesh";
-	filters = MESH_EXTENSION;
-	startPath = "Assets/Meshes";
-}
-

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.cpp
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.cpp
@@ -6,16 +6,48 @@
 #include "Application.h"
 #include "FileSystem/ModuleResources.h"
 
+WindowTextureInput::WindowTextureInput(ComponentMaterial* material,
+	TextureType textureType) :
+	WindowFileBrowser(),
+	materialComponent(material),
+	textureType(textureType)
+{
+	dialogName = "Select Texture";
+
+	switch (textureType)
+	{
+	case TextureType::DIFFUSE:
+		title = "Load Diffuse";
+		break;
+	case TextureType::NORMAL:
+		title = "Load Normal";
+		break;
+	case TextureType::OCCLUSION:
+		title = "Load Occlusion";
+		break;
+	case TextureType::SPECULAR:
+		title = "Load Specular";
+		break;
+	default:
+		break;
+	}
+
+	filters = "Image files (*.png *.gif *.jpg *.jpeg *.dds *.tif *.tga){.png,.gif,.jpg,.jpeg,.dds,.tif,.tga}";
+	startPath = "Assets/Textures";
+}
+
+WindowTextureInput::~WindowTextureInput()
+{
+}
 
 void WindowTextureInput::DoThisIfOk()
 {
-	std::shared_ptr<ComponentMaterial> asShared = materialComponent.lock();
-	if (asShared)
+	if (materialComponent)
 	{
 		std::string filePath = std::string(fileDialogImporter.GetFilePathName());
 		UID uidTexture = App->resources->ImportResource(filePath);
 
-		std::shared_ptr<ResourceMaterial> materialAsShared = asShared->GetMaterial().lock();
+		std::shared_ptr<ResourceMaterial> materialAsShared = materialComponent->GetMaterial().lock();
 
 		if (materialAsShared)
 		{

--- a/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.h
+++ b/Source/DataModels/Windows/EditorWindows/ImporterWindows/WindowTextureInput.h
@@ -9,47 +9,13 @@ class WindowTextureInput :
     public WindowFileBrowser
 {
 public:
-	WindowTextureInput(const std::weak_ptr<ComponentMaterial>& material, TextureType textureType);
+	WindowTextureInput(ComponentMaterial* material, TextureType textureType);
 	~WindowTextureInput();
 	void DoThisIfOk() override;
 
 private:
-	std::weak_ptr<ComponentMaterial> materialComponent;
+	ComponentMaterial* materialComponent;
 	TextureType textureType;
 
 	friend class WindowComponentMaterial;
 };
-
-inline WindowTextureInput::WindowTextureInput(const std::weak_ptr<ComponentMaterial>& material,
-											  TextureType textureType) :
-	WindowFileBrowser(),
-	materialComponent(material),
-	textureType(textureType)
-{
-	dialogName = "Select Texture";
-
-	switch (textureType)
-	{
-	case TextureType::DIFFUSE:
-		title = "Load Diffuse";
-		break;
-	case TextureType::NORMAL:
-		title = "Load Normal";
-		break;
-	case TextureType::OCCLUSION:
-		title = "Load Occlusion";
-		break;
-	case TextureType::SPECULAR:
-		title = "Load Specular";
-		break;
-	default:
-		break;
-	}
-
-	filters = "Image files (*.png *.gif *.jpg *.jpeg *.dds *.tif *.tga){.png,.gif,.jpg,.jpeg,.dds,.tif,.tga}";
-	startPath = "Assets/Textures";
-}
-
-inline WindowTextureInput::~WindowTextureInput()
-{
-}

--- a/Source/DataModels/Windows/EditorWindows/WindowFileBrowser.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowFileBrowser.cpp
@@ -4,17 +4,76 @@
 #include "Application.h"
 #include "FileSystem/ModuleResources.h"
 
+WindowFileBrowser::WindowFileBrowser() : EditorWindow("File Browser"),
+	title(ICON_IGFD_FOLDER " Import Asset"),
+	dialogName("Choose File"),
+	filters(".*"),
+	startPath("."),
+	browserPath(fileDialogBrowser.GetCurrentPath() + "Assets")
+{
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByFullName, "(Custom.+[.]h)",
+		ImVec4(1.0f, 1.0f, 0.0f, 0.9f));
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".cpp",
+		ImVec4(1.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".h",
+		ImVec4(0.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".hpp",
+		ImVec4(0.0f, 0.0f, 1.0f, 0.9f), ICON_IGFD_FILE);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".md",
+		ImVec4(1.0f, 0.0f, 1.0f, 0.9f));
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".png",
+		ImVec4(0.0f, 1.0f, 1.0f, 0.9f), ICON_IGFD_FILE_PIC);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".gif",
+		ImVec4(0.0f, 1.0f, 0.5f, 0.9f), "[GIF]");
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeDir, nullptr,
+		ImVec4(0.5f, 1.0f, 0.9f, 0.9f), ICON_IGFD_FOLDER);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeFile, "CMakeLists.txt",
+		ImVec4(0.1f, 0.5f, 0.5f, 0.9f), ICON_IGFD_ADD);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByFullName, "doc",
+		ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_FILE_PIC);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeDir | IGFD_FileStyleByContainedInFullName, ".git",
+		ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_BOOKMARK);
+	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeFile | IGFD_FileStyleByContainedInFullName, ".git",
+		ImVec4(0.5f, 0.8f, 0.5f, 0.9f), ICON_IGFD_SAVE);
+
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByFullName, "(Custom.+[.]h)",
+		ImVec4(1.0f, 1.0f, 0.0f, 0.9f));
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".cpp",
+		ImVec4(1.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".h",
+		ImVec4(0.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".hpp",
+		ImVec4(0.0f, 0.0f, 1.0f, 0.9f), ICON_IGFD_FILE);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".md",
+		ImVec4(1.0f, 0.0f, 1.0f, 0.9f));
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".png",
+		ImVec4(0.0f, 1.0f, 1.0f, 0.9f), ICON_IGFD_FILE_PIC);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".gif",
+		ImVec4(0.0f, 1.0f, 0.5f, 0.9f), "[GIF]");
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeDir, nullptr,
+		ImVec4(0.5f, 1.0f, 0.9f, 0.9f), ICON_IGFD_FOLDER);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeFile, "CMakeLists.txt",
+		ImVec4(0.1f, 0.5f, 0.5f, 0.9f), ICON_IGFD_ADD);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByFullName, "doc",
+		ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_FILE_PIC);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeDir | IGFD_FileStyleByContainedInFullName, ".git",
+		ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_BOOKMARK);
+	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeFile | IGFD_FileStyleByContainedInFullName, ".git",
+		ImVec4(0.5f, 0.8f, 0.5f, 0.9f), ICON_IGFD_SAVE);
+
+}
+
 void WindowFileBrowser::DrawWindowContents()
 {
 	//WindowImporter
-	if (ImGui::Button(title))
+	if (ImGui::Button(title.c_str()))
 	{
 		Uint32 flags = ImGuiFileDialogFlags_Modal;
 		if (isSave)
 		{
 			flags |= ImGuiFileDialogFlags_ConfirmOverwrite;
 		}
-		fileDialogImporter.OpenDialog("ChooseFileDlgKey", dialogName, filters, startPath,
+		fileDialogImporter.OpenDialog("ChooseFileDlgKey", dialogName.c_str(), filters.c_str(), startPath.c_str(),
 			"", 1, nullptr, flags);
 	}
 	// display

--- a/Source/DataModels/Windows/EditorWindows/WindowFileBrowser.h
+++ b/Source/DataModels/Windows/EditorWindows/WindowFileBrowser.h
@@ -16,10 +16,10 @@ protected:
 	ImVec2 GetStartingSize() const override;
 
 	bool isSave = false;
-	const char* dialogName;
-	const char* title;
-	const char* filters;
-	const char* startPath;
+	std::string dialogName;
+	std::string title;
+	std::string filters;
+	std::string startPath;
 	std::string browserPath;
 
 	ImGuiFileDialog fileDialogBrowser;
@@ -30,39 +30,4 @@ protected:
 inline ImVec2 WindowFileBrowser::GetStartingSize() const
 {
 	return ImVec2(900, 250);
-}
-inline WindowFileBrowser::WindowFileBrowser() : EditorWindow("File Browser")
-{
-	title = ICON_IGFD_FOLDER " Import Asset";
-	dialogName = "Choose File";
-	filters = "Source files (*.cpp *.h *.hpp){.cpp,.h,.hpp},Image files (*.png *.gif *.jpg *.jpeg *.dds){.png,.gif,.jpg,.jpeg,.dds},.md,.*";
-	startPath = ".";
-	browserPath = fileDialogBrowser.GetCurrentPath() + "Assets";
-
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByFullName, "(Custom.+[.]h)", ImVec4(1.0f, 1.0f, 0.0f, 0.9f));
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".cpp", ImVec4(1.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".h", ImVec4(0.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".hpp", ImVec4(0.0f, 0.0f, 1.0f, 0.9f), ICON_IGFD_FILE);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".md", ImVec4(1.0f, 0.0f, 1.0f, 0.9f));
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".png", ImVec4(0.0f, 1.0f, 1.0f, 0.9f), ICON_IGFD_FILE_PIC);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByExtention, ".gif", ImVec4(0.0f, 1.0f, 0.5f, 0.9f), "[GIF]");
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeDir, nullptr, ImVec4(0.5f, 1.0f, 0.9f, 0.9f), ICON_IGFD_FOLDER);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeFile, "CMakeLists.txt", ImVec4(0.1f, 0.5f, 0.5f, 0.9f), ICON_IGFD_ADD);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByFullName, "doc", ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_FILE_PIC);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeDir | IGFD_FileStyleByContainedInFullName, ".git", ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_BOOKMARK);
-	fileDialogBrowser.SetFileStyle(IGFD_FileStyleByTypeFile | IGFD_FileStyleByContainedInFullName, ".git", ImVec4(0.5f, 0.8f, 0.5f, 0.9f), ICON_IGFD_SAVE);
-
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByFullName, "(Custom.+[.]h)", ImVec4(1.0f, 1.0f, 0.0f, 0.9f));
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".cpp", ImVec4(1.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".h", ImVec4(0.0f, 1.0f, 0.0f, 0.9f), ICON_IGFD_FILE);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".hpp", ImVec4(0.0f, 0.0f, 1.0f, 0.9f), ICON_IGFD_FILE);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".md", ImVec4(1.0f, 0.0f, 1.0f, 0.9f));
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".png", ImVec4(0.0f, 1.0f, 1.0f, 0.9f), ICON_IGFD_FILE_PIC);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByExtention, ".gif", ImVec4(0.0f, 1.0f, 0.5f, 0.9f), "[GIF]");
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeDir, nullptr, ImVec4(0.5f, 1.0f, 0.9f, 0.9f), ICON_IGFD_FOLDER);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeFile, "CMakeLists.txt", ImVec4(0.1f, 0.5f, 0.5f, 0.9f), ICON_IGFD_ADD);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByFullName, "doc", ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_FILE_PIC);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeDir | IGFD_FileStyleByContainedInFullName, ".git", ImVec4(0.9f, 0.2f, 0.0f, 0.9f), ICON_IGFD_BOOKMARK);
-	fileDialogImporter.SetFileStyle(IGFD_FileStyleByTypeFile | IGFD_FileStyleByContainedInFullName, ".git", ImVec4(0.5f, 0.8f, 0.5f, 0.9f), ICON_IGFD_SAVE);
-
 }

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.cpp
@@ -26,17 +26,17 @@ void WindowHierarchy::DrawWindowContents()
 {
     if (App->scene->GetLoadedScene()->GetRoot())
     {
-        DrawRecursiveHierarchy(App->scene->GetLoadedScene()->GetRoot());
+        DrawRecursiveHierarchy(App->scene->GetLoadedScene()->GetRoot().get());
     }
 }
 
-void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& gameObject)
+void WindowHierarchy::DrawRecursiveHierarchy(GameObject* gameObject)
 {
     assert(gameObject != nullptr);   
 
     char gameObjectLabel[160];  // Label created so ImGui can differentiate the GameObjects
                                 // that have the same name in the hierarchy window
-    sprintf_s(gameObjectLabel, "%s###%p", gameObject->GetName(), gameObject.get());
+    sprintf_s(gameObjectLabel, "%s###%p", gameObject->GetName(), gameObject);
 
     ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow;
     if (gameObject->GetChildren().empty())
@@ -44,12 +44,12 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
         flags |= ImGuiTreeNodeFlags_Leaf;
     }
 
-    if (gameObject == App->scene->GetLoadedScene()->GetRoot())
+    if (gameObject == App->scene->GetLoadedScene()->GetRoot().get())
     {
         flags |= ImGuiTreeNodeFlags_DefaultOpen;
     }
     
-    if (App->scene->GetSelectedGameObject().lock() == gameObject)
+    if (gameObject == App->scene->GetSelectedGameObject().lock().get())
     {
         flags |= ImGuiTreeNodeFlags_Selected;
     }
@@ -72,8 +72,8 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
     {
         App->scene->GetLoadedScene()->GetSceneQuadTree()
             ->AddGameObjectAndChildren(App->scene->GetSelectedGameObject().lock());
-        App->scene->SetSelectedGameObject(gameObject);
-        App->scene->GetLoadedScene()->GetSceneQuadTree()->RemoveGameObjectAndChildren(gameObject);
+        App->scene->SetSelectedGameObject(gameObject->shared_from_this() /*This MUST be removed*/);
+        App->scene->GetLoadedScene()->GetSceneQuadTree()->RemoveGameObjectAndChildren(gameObject->shared_from_this() /*This MUST be removed*/);
     }
 
     ImGui::PushID(gameObjectLabel);
@@ -81,12 +81,12 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
     {
         if (ImGui::MenuItem("Create child"))
         {
-            App->scene->GetLoadedScene()->CreateGameObject("Empty GameObject", gameObject);
+            App->scene->GetLoadedScene()->CreateGameObject("Empty GameObject", gameObject->shared_from_this() /*This MUST be removed*/);
         }
         if (ImGui::MenuItem("Create camera"))
         {
             std::shared_ptr<GameObject> newCamera =
-                App->scene->GetLoadedScene()->CreateCameraGameObject("Basic Camera", gameObject);
+                App->scene->GetLoadedScene()->CreateCameraGameObject("Basic Camera", gameObject->shared_from_this() /*This MUST be removed*/);
         }
 
         /*
@@ -131,20 +131,20 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
         }
         */
 
-        if (gameObject != App->scene->GetLoadedScene()->GetRoot() &&
-            gameObject != App->scene->GetLoadedScene()->GetAmbientLight() &&
-            gameObject != App->scene->GetLoadedScene()->GetDirectionalLight())
+        if (gameObject != App->scene->GetLoadedScene()->GetRoot().get() &&
+            gameObject != App->scene->GetLoadedScene()->GetAmbientLight().get() &&
+            gameObject != App->scene->GetLoadedScene()->GetDirectionalLight().get())
         {
             if (ImGui::MenuItem("Delete"))
             {
-                if (App->scene->GetSelectedGameObject().lock() == gameObject)
+                if (gameObject == App->scene->GetSelectedGameObject().lock().get())
                 {
                     App->scene->SetSelectedGameObject(gameObject->GetParent()); // If a GameObject is destroyed, 
                                                                                 // change the focus to its parent
                     App->scene->GetLoadedScene()->GetSceneQuadTree()->RemoveGameObjectAndChildren(gameObject->GetParent().lock());
                 }
-                App->scene->GetLoadedScene()->GetSceneQuadTree()->RemoveGameObjectAndChildren(gameObject);
-                App->scene->GetLoadedScene()->DestroyGameObject(gameObject);
+                App->scene->GetLoadedScene()->GetSceneQuadTree()->RemoveGameObjectAndChildren(gameObject->shared_from_this() /*This MUST be removed*/);
+                App->scene->GetLoadedScene()->DestroyGameObject(gameObject->shared_from_this() /*This MUST be removed*/);
             }
         }
 
@@ -152,7 +152,7 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
     }
     ImGui::PopID();
 
-    if (gameObject != App->scene->GetLoadedScene()->GetRoot()) // The root cannot be moved around
+    if (gameObject != App->scene->GetLoadedScene()->GetRoot().get()) // The root cannot be moved around
     {
         if (ImGui::BeginDragDropSource())
         {
@@ -173,7 +173,7 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
                 App->scene->GetLoadedScene()->SearchGameObjectByID(draggedGameObjectID);
             std::shared_ptr<GameObject> asShared = draggedGameObject.lock();
             if (asShared)
-                asShared->SetParent(gameObject);
+                asShared->SetParent(gameObject->shared_from_this() /*This MUST be removed*/);
         }
 
         ImGui::EndDragDropTarget();
@@ -183,7 +183,7 @@ void WindowHierarchy::DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& 
     {
         for (int i = 0; i < gameObject->GetChildren().size(); ++i)
         {
-            DrawRecursiveHierarchy(gameObject->GetChildren()[i].lock());
+            DrawRecursiveHierarchy(gameObject->GetChildren()[i].lock().get());
         }
 
         ImGui::TreePop();

--- a/Source/DataModels/Windows/EditorWindows/WindowHierarchy.h
+++ b/Source/DataModels/Windows/EditorWindows/WindowHierarchy.h
@@ -14,9 +14,8 @@ protected:
 
 	ImVec2 GetStartingSize() const override;
 
-
 private:
-	void DrawRecursiveHierarchy(const std::shared_ptr<GameObject>& gameObject);
+	void DrawRecursiveHierarchy(GameObject* gameObject);
 };
 
 inline ImVec2 WindowHierarchy::GetStartingSize() const

--- a/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
+++ b/Source/DataModels/Windows/EditorWindows/WindowInspector.cpp
@@ -129,7 +129,7 @@ void WindowInspector::DrawWindowContents()
 
 			for (std::weak_ptr<Component> component : currentGameObject->GetComponents())
 			{
-				windowsForComponentsOfSelectedObject.push_back(ComponentWindow::CreateWindowForComponent(component));
+				windowsForComponentsOfSelectedObject.push_back(ComponentWindow::CreateWindowForComponent(component.lock().get()));
 			}
 		}
 		for (int i = 0; i < windowsForComponentsOfSelectedObject.size(); ++i)

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/ComponentWindow.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/ComponentWindow.h
@@ -11,13 +11,13 @@ class ComponentWindow : public SubWindow
 public:
 	virtual ~ComponentWindow() override;
 
-	static std::unique_ptr<ComponentWindow> CreateWindowForComponent(const std::weak_ptr<Component>& component);
+	static std::unique_ptr<ComponentWindow> CreateWindowForComponent(Component* component);
 
 protected:
-	ComponentWindow(const std::string& name, const std::weak_ptr<Component>& component);
+	ComponentWindow(const std::string& name, Component* component);
 	void DrawEnableAndDeleteComponent();
 
-	std::weak_ptr<Component> component;
+	Component* component;
 
 private:
 	void DrawEnableComponent();

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAmbient.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAmbient.cpp
@@ -5,7 +5,7 @@
 #include "DataModels/Scene/Scene.h"
 #include "DataModels/Components/ComponentAmbient.h"
 
-WindowComponentAmbient::WindowComponentAmbient(const std::weak_ptr<ComponentAmbient>& component) :
+WindowComponentAmbient::WindowComponentAmbient(ComponentAmbient* component) :
 	ComponentWindow("AMBIENT LIGHT", component)
 {
 }
@@ -14,10 +14,9 @@ void WindowComponentAmbient::DrawWindowContents()
 {
 	this->DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentAmbient> asSharedAmbient =
-		std::dynamic_pointer_cast<ComponentAmbient>(this->component.lock());
+	ComponentAmbient* asAmbient = static_cast<ComponentAmbient*>(this->component);
 
-	if (asSharedAmbient)
+	if (asAmbient)
 	{
 		ImGui::Dummy(ImVec2(0.0f, 2.5f));
 
@@ -28,10 +27,10 @@ void WindowComponentAmbient::DrawWindowContents()
 			ImGui::Text("Color");
 			ImGui::SameLine();
 
-			float3 color = asSharedAmbient->GetColor();
+			float3 color = asAmbient->GetColor();
 			if (ImGui::ColorEdit3("MyColor##1", (float*)&color))
 			{
-				asSharedAmbient->SetColor(color);
+				asAmbient->SetColor(color);
 				App->scene->GetLoadedScene()->RenderAmbientLight();
 			}
 			ImGui::EndTable();

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAmbient.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentAmbient.h
@@ -7,7 +7,7 @@ class ComponentAmbient;
 class WindowComponentAmbient : public ComponentWindow
 {
 public:
-	WindowComponentAmbient(const std::weak_ptr<ComponentAmbient>& component);
+	WindowComponentAmbient(ComponentAmbient* component);
 	~WindowComponentAmbient() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentBoundingBoxes.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentBoundingBoxes.cpp
@@ -2,19 +2,18 @@
 
 #include "DataModels/Components/ComponentBoundingBoxes.h"
 
-WindowComponentBoundingBoxes::WindowComponentBoundingBoxes(const std::weak_ptr<ComponentBoundingBoxes>& component)
+WindowComponentBoundingBoxes::WindowComponentBoundingBoxes(ComponentBoundingBoxes* component)
 	: ComponentWindow("BOUNDING BOX", component)
 {
 }
 
 void WindowComponentBoundingBoxes::DrawWindowContents()
 {
-	std::shared_ptr<ComponentBoundingBoxes> asSharedBB =
-		std::dynamic_pointer_cast<ComponentBoundingBoxes>(this->component.lock());
+	ComponentBoundingBoxes* asBB = static_cast<ComponentBoundingBoxes*>(this->component);
 
-	if (asSharedBB)
+	if (asBB)
 	{
 		ImGui::Text("Draw Bounding Box"); ImGui::SameLine();
-		ImGui::Checkbox("##Draw Bounding Box", &(asSharedBB->drawBoundingBoxes));
+		ImGui::Checkbox("##Draw Bounding Box", &(asBB->drawBoundingBoxes));
 	}
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentBoundingBoxes.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentBoundingBoxes.h
@@ -7,7 +7,7 @@ class ComponentBoundingBoxes;
 class WindowComponentBoundingBoxes : public ComponentWindow
 {
 public:
-	WindowComponentBoundingBoxes(const std::weak_ptr<ComponentBoundingBoxes>& component);
+	WindowComponentBoundingBoxes(ComponentBoundingBoxes* component);
 	~WindowComponentBoundingBoxes() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.cpp
@@ -2,7 +2,7 @@
 
 #include "DataModels/Components/ComponentCamera.h"
 
-WindowComponentCamera::WindowComponentCamera(const std::weak_ptr<ComponentCamera>& component) :
+WindowComponentCamera::WindowComponentCamera(ComponentCamera* component) :
 	ComponentWindow("CAMERA", component)
 {
 }
@@ -11,16 +11,15 @@ void WindowComponentCamera::DrawWindowContents()
 {
 	this->DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentCamera> asSharedCamera =
-		std::dynamic_pointer_cast<ComponentCamera>(this->component.lock());
+	ComponentCamera* asCamera = static_cast<ComponentCamera*>(this->component);
 
-	if (asSharedCamera)
+	if (asCamera)
 	{
 		const char* listbox_items[] = { "Basic Frustum", "Offset Frustum", "No Frustum" };
 
-		bool drawFrustum = asSharedCamera->IsDrawFrustum();
-		int frustumMode = asSharedCamera->GetFrustumMode();
-		float frustumOffset = asSharedCamera->GetFrustumOffset();
+		bool drawFrustum = asCamera->IsDrawFrustum();
+		int frustumMode = asCamera->GetFrustumMode();
+		float frustumOffset = asCamera->GetFrustumOffset();
 
 		ImGui::Text("Draw Frustum"); ImGui::SameLine();
 		ImGui::Checkbox("##Draw Frustum", &drawFrustum);
@@ -30,8 +29,8 @@ void WindowComponentCamera::DrawWindowContents()
 
 		ImGui::Separator();
 
-		asSharedCamera->SetDrawFrustum(drawFrustum);
-		asSharedCamera->SetFrustumMode(frustumMode);
-		asSharedCamera->SetFrustumOffset(frustumOffset);
+		asCamera->SetDrawFrustum(drawFrustum);
+		asCamera->SetFrustumMode(frustumMode);
+		asCamera->SetFrustumOffset(frustumOffset);
 	}
 }

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentCamera.h
@@ -7,7 +7,7 @@ class ComponentCamera;
 class WindowComponentCamera : public ComponentWindow
 {
 public:
-	WindowComponentCamera(const std::weak_ptr<ComponentCamera>& component);
+	WindowComponentCamera(ComponentCamera* component);
 	~WindowComponentCamera() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentDirLight.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentDirLight.cpp
@@ -5,7 +5,7 @@
 #include "DataModels/Scene/Scene.h"
 #include "DataModels/Components/ComponentDirLight.h"
 
-WindowComponentDirLight::WindowComponentDirLight(const std::weak_ptr<ComponentDirLight>& component) :
+WindowComponentDirLight::WindowComponentDirLight(ComponentDirLight* component) :
 	ComponentWindow("DIRECTIONAL LIGHT", component)
 {
 }
@@ -14,10 +14,9 @@ void WindowComponentDirLight::DrawWindowContents()
 {
 	this->DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentDirLight> asSharedDirLight =
-		std::dynamic_pointer_cast<ComponentDirLight>(this->component.lock());
+	ComponentDirLight* asDirLight = static_cast<ComponentDirLight*>(this->component);
 
-	if (asSharedDirLight)
+	if (asDirLight)
 	{
 		const char* lightTypes[] = { "Point", "Spot" };
 
@@ -32,19 +31,19 @@ void WindowComponentDirLight::DrawWindowContents()
 			ImGui::Text("Intensity"); ImGui::SameLine();
 			ImGui::SetNextItemWidth(80.0f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(5.0f, 1.0f));
-			float intensity = asSharedDirLight->GetIntensity();
+			float intensity = asDirLight->GetIntensity();
 			if (ImGui::DragFloat("##Intensity", &intensity, 0.01f, 0.0f, 1.0f))
 			{
-				asSharedDirLight->SetIntensity(intensity);
+				asDirLight->SetIntensity(intensity);
 				modified = true;
 			}
 			ImGui::PopStyleVar();
 
 			ImGui::Text("Color"); ImGui::SameLine();
-			float3 color = asSharedDirLight->GetColor();
+			float3 color = asDirLight->GetColor();
 			if (ImGui::ColorEdit3("MyColor##1", (float*)&color))
 			{
-				asSharedDirLight->SetColor(color);
+				asDirLight->SetColor(color);
 				modified = true;
 			}
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentDirLight.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentDirLight.h
@@ -7,7 +7,7 @@ class ComponentDirLight;
 class WindowComponentDirLight : public ComponentWindow
 {
 public:
-	WindowComponentDirLight(const std::weak_ptr<ComponentDirLight>& component);
+	WindowComponentDirLight(ComponentDirLight* component);
 	~WindowComponentDirLight() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentLight.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentLight.cpp
@@ -2,8 +2,8 @@
 
 #include "DataModels/Components/ComponentLight.h"
 
-WindowComponentLight::WindowComponentLight(const std::weak_ptr<ComponentLight>& component) :
-	ComponentWindow("BASIC LIGHT", std::weak_ptr<Component>())
+WindowComponentLight::WindowComponentLight(ComponentLight* component) :
+	ComponentWindow("BASIC LIGHT", component)
 {
 }
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentLight.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentLight.h
@@ -7,7 +7,7 @@ class ComponentLight;
 class WindowComponentLight : public ComponentWindow
 {
 public:
-	WindowComponentLight(const std::weak_ptr<ComponentLight>& component);
+	WindowComponentLight(ComponentLight* component);
 	~WindowComponentLight() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMaterial.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMaterial.cpp
@@ -11,7 +11,7 @@
 #include "DataModels/Resources/ResourceMaterial.h"
 #include "DataModels/Resources/ResourceTexture.h"
 
-WindowComponentMaterial::WindowComponentMaterial(const std::weak_ptr<ComponentMaterial>& component) :
+WindowComponentMaterial::WindowComponentMaterial(ComponentMaterial* component) :
 	ComponentWindow("MATERIAL", component)
 {
 	inputMaterial = std::make_unique<WindowMaterialInput>(component);
@@ -24,12 +24,11 @@ void WindowComponentMaterial::DrawWindowContents()
 {
 	DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentMaterial> asSharedMaterial =
-		std::dynamic_pointer_cast<ComponentMaterial>(component.lock());
+	ComponentMaterial* asMaterial = static_cast<ComponentMaterial*>(this->component);
 
-	if (asSharedMaterial)
+	if (asMaterial)
 	{
-		std::shared_ptr<ResourceMaterial> materialResource = asSharedMaterial->GetMaterial().lock();
+		std::shared_ptr<ResourceMaterial> materialResource = asMaterial->GetMaterial().lock();
 		if (materialResource)
 		{
 			DrawSetMaterial();
@@ -43,12 +42,11 @@ void WindowComponentMaterial::DrawWindowContents()
 
 void WindowComponentMaterial::DrawSetMaterial()
 {
-	std::shared_ptr<ComponentMaterial> asSharedMaterial =
-		std::dynamic_pointer_cast<ComponentMaterial>(component.lock());
+	ComponentMaterial* asMaterial = static_cast<ComponentMaterial*>(this->component);
 
-	if (asSharedMaterial)
+	if (asMaterial)
 	{
-		std::shared_ptr<ResourceMaterial> materialResource = asSharedMaterial->GetMaterial().lock();
+		std::shared_ptr<ResourceMaterial> materialResource = asMaterial->GetMaterial().lock();
 		if (materialResource)
 		{
 			ImGui::Text("");
@@ -58,15 +56,15 @@ void WindowComponentMaterial::DrawSetMaterial()
 
 			ImGui::Text("");
 
-			static float3 colorDiffuse = asSharedMaterial->GetDiffuseColor();
+			static float3 colorDiffuse = asMaterial->GetDiffuseColor();
 			ImGui::Text("Diffuse Color:"); ImGui::SameLine();
 			if (ImGui::ColorEdit3("##Diffuse Color", (float*)&colorDiffuse))
-				asSharedMaterial->SetDiffuseColor(colorDiffuse);
+				asMaterial->SetDiffuseColor(colorDiffuse);
 
-			static float3 colorSpecular = asSharedMaterial->GetSpecularColor();
+			static float3 colorSpecular = asMaterial->GetSpecularColor();
 			ImGui::Text("Specular Color:"); ImGui::SameLine();
 			if (ImGui::ColorEdit3("##Specular Color", (float*)&colorSpecular))
-				asSharedMaterial->SetSpecularColor(colorSpecular);
+				asMaterial->SetSpecularColor(colorSpecular);
 
 			ImGui::Text("");
 
@@ -86,7 +84,7 @@ void WindowComponentMaterial::DrawSetMaterial()
 
 			if (ImGui::Button(removeButtonLabel.c_str()) && materialResource)
 			{
-				asSharedMaterial->UnloadTextures();
+				asMaterial->UnloadTextures();
 				
 				UID uidNull = 0;
 				materialResource->SetDiffuseUID(uidNull);
@@ -96,14 +94,14 @@ void WindowComponentMaterial::DrawSetMaterial()
 				
 				materialResource->SetChanged(true);
 				
-				asSharedMaterial->diffuseUID = 0;
-				asSharedMaterial->normalUID = 0;
-				asSharedMaterial->occlusionUID = 0;
-				asSharedMaterial->specularUID = 0;
+				asMaterial->diffuseUID = 0;
+				asMaterial->normalUID = 0;
+				asMaterial->occlusionUID = 0;
+				asMaterial->specularUID = 0;
 			}
 
-			ImGui::Checkbox("Use specular Alpha as shininess", &(asSharedMaterial->hasShininessAlpha));
-			ImGui::SliderFloat("Shininess", &(asSharedMaterial->shininess),
+			ImGui::Checkbox("Use specular Alpha as shininess", &(asMaterial->hasShininessAlpha));
+			ImGui::SliderFloat("Shininess", &(asMaterial->shininess),
 				0.1f, 200.f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
 			ImGui::Separator();
 
@@ -133,11 +131,11 @@ void WindowComponentMaterial::DrawSetMaterial()
 			{
 				if (ImGui::Button("Remove Texture Diffuse") && materialResource->GetDiffuseUID())
 				{
-					asSharedMaterial->UnloadTexture(TextureType::DIFFUSE);
+					asMaterial->UnloadTexture(TextureType::DIFFUSE);
 
 					UID uidNull = 0;
 					materialResource->SetDiffuseUID(uidNull);
-					asSharedMaterial->diffuseUID = 0;
+					asMaterial->diffuseUID = 0;
 				}
 			}
 
@@ -165,11 +163,11 @@ void WindowComponentMaterial::DrawSetMaterial()
 			{
 				if (ImGui::Button("Remove Texture Specular") && materialResource->GetSpecularUID())
 				{
-					asSharedMaterial->UnloadTexture(TextureType::SPECULAR);
+					asMaterial->UnloadTexture(TextureType::SPECULAR);
 
 					UID uidNull = 0;
 					materialResource->SetSpecularUID(uidNull);
-					asSharedMaterial->specularUID = 0;
+					asMaterial->specularUID = 0;
 				}
 			}
 
@@ -197,14 +195,14 @@ void WindowComponentMaterial::DrawSetMaterial()
 			{
 				if (materialResource->GetNormalUID())
 				{
-					asSharedMaterial->UnloadTexture(TextureType::NORMAL);
+					asMaterial->UnloadTexture(TextureType::NORMAL);
 
 					UID uidNull = 0;
 					materialResource->SetNormalUID(uidNull);
-					asSharedMaterial->normalUID = 0;
+					asMaterial->normalUID = 0;
 				}
 			}
-			ImGui::SliderFloat("Normal", &(asSharedMaterial->normalStrength),
+			ImGui::SliderFloat("Normal", &(asMaterial->normalStrength),
 				0.0f, 1.0f, "%.1f", ImGuiSliderFlags_AlwaysClamp);
 
 			ImGui::Text("");
@@ -214,12 +212,11 @@ void WindowComponentMaterial::DrawSetMaterial()
 
 void WindowComponentMaterial::DrawEmptyMaterial()
 {
-	std::shared_ptr<ComponentMaterial> asSharedMaterial =
-		std::dynamic_pointer_cast<ComponentMaterial>(component.lock());
+	ComponentMaterial* asMaterial = static_cast<ComponentMaterial*>(this->component);
 
-	if (asSharedMaterial)
+	if (asMaterial)
 	{
-		if (asSharedMaterial->GetMaterial().expired())
+		if (asMaterial->GetMaterial().expired())
 		{
 			inputMaterial->DrawWindowContents();
 		}

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMaterial.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMaterial.h
@@ -9,7 +9,7 @@ class WindowMaterialInput;
 class WindowComponentMaterial : public ComponentWindow
 {
 public:
-	WindowComponentMaterial(const std::weak_ptr<ComponentMaterial>& component);
+	WindowComponentMaterial(ComponentMaterial* component);
 	~WindowComponentMaterial() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.cpp
@@ -9,7 +9,7 @@
 
 #include "DataModels/Resources/ResourceMesh.h"
 
-WindowComponentMeshRenderer::WindowComponentMeshRenderer(const std::weak_ptr<ComponentMeshRenderer>& component) :
+WindowComponentMeshRenderer::WindowComponentMeshRenderer(ComponentMeshRenderer* component) :
 	ComponentWindow("MESH RENDERER", component)
 {
 	inputMesh = std::make_unique<WindowMeshInput>(component);
@@ -19,12 +19,11 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 {
 	this->DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentMeshRenderer> asSharedMeshRenderer =
-		std::dynamic_pointer_cast<ComponentMeshRenderer>(this->component.lock());
+	ComponentMeshRenderer* asMeshRenderer = static_cast<ComponentMeshRenderer*>(this->component);
 
-	if (asSharedMeshRenderer)
+	if (asMeshRenderer)
 	{
-		std::shared_ptr<ResourceMesh> meshAsShared = asSharedMeshRenderer->GetMesh().lock();
+		std::shared_ptr<ResourceMesh> meshAsShared = asMeshRenderer->GetMesh().lock();
 		static char* meshPath = (char*)("unknown");
 
 		if (meshAsShared)
@@ -51,7 +50,7 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 				if (newMesh)
 				{
 					meshAsShared->Unload();
-					asSharedMeshRenderer->SetMesh(newMesh);
+					asMeshRenderer->SetMesh(newMesh);
 				}
 			}
 
@@ -71,7 +70,7 @@ void WindowComponentMeshRenderer::DrawWindowContents()
 		else if (ImGui::Button("Remove Mesh"))
 		{
 			meshAsShared->Unload();
-			asSharedMeshRenderer->SetMesh(std::weak_ptr<ResourceMesh>());
+			asMeshRenderer->SetMesh(std::weak_ptr<ResourceMesh>());
 		}
 
 		if (ImGui::BeginTable("##GeometryTable", 2))

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentMeshRenderer.h
@@ -8,7 +8,7 @@ class WindowMeshInput;
 class WindowComponentMeshRenderer : public ComponentWindow
 {
 public:
-	WindowComponentMeshRenderer(const std::weak_ptr<ComponentMeshRenderer>& component);
+	WindowComponentMeshRenderer(ComponentMeshRenderer* component);
 	~WindowComponentMeshRenderer() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentPointLight.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentPointLight.cpp
@@ -7,7 +7,7 @@
 #include "DataModels/Components/ComponentPointLight.h"
 #include "DataModels/Components/ComponentSpotLight.h"
 
-WindowComponentPointLight::WindowComponentPointLight(const std::weak_ptr<ComponentPointLight>& component) :
+WindowComponentPointLight::WindowComponentPointLight(ComponentPointLight* component) :
 	ComponentWindow("POINT LIGHT", component)
 {
 }
@@ -16,10 +16,9 @@ void WindowComponentPointLight::DrawWindowContents()
 {
 	this->DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentPointLight> asSharedPointLight =
-		std::dynamic_pointer_cast<ComponentPointLight>(this->component.lock());
+	ComponentPointLight* asPointLight = static_cast<ComponentPointLight*>(this->component);
 
-	if (asSharedPointLight)
+	if (asPointLight)
 	{
 		const char* lightTypes[] = { "Point", "Spot" };
 
@@ -45,14 +44,14 @@ void WindowComponentPointLight::DrawWindowContents()
 						if (lightTypes[i] == "Spot")
 						{
 							std::shared_ptr<ComponentSpotLight> newSpot =
-								std::static_pointer_cast<ComponentSpotLight>(asSharedPointLight->GetOwner().lock()
+								std::static_pointer_cast<ComponentSpotLight>(asPointLight->GetOwner().lock()
 									->CreateComponentLight(LightType::SPOT));
 
-							newSpot->SetColor(asSharedPointLight->GetColor());
-							newSpot->SetIntensity(asSharedPointLight->GetIntensity());
-							newSpot->SetRadius(asSharedPointLight->GetRadius());
+							newSpot->SetColor(asPointLight->GetColor());
+							newSpot->SetIntensity(asPointLight->GetIntensity());
+							newSpot->SetRadius(asPointLight->GetRadius());
 
-							asSharedPointLight->GetOwner().lock()->RemoveComponent(asSharedPointLight);
+							asPointLight->GetOwner().lock()->RemoveComponent(asPointLight->shared_from_this() /*this MUST be removed once Scene is updated*/);
 
 							App->scene->GetLoadedScene()->UpdateSceneSpotLights();
 							App->scene->GetLoadedScene()->RenderSpotLights();
@@ -74,29 +73,29 @@ void WindowComponentPointLight::DrawWindowContents()
 			ImGui::Text("Intensity"); ImGui::SameLine();
 			ImGui::SetNextItemWidth(80.0f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(5.0f, 1.0f));
-			float intensity = asSharedPointLight->GetIntensity();
+			float intensity = asPointLight->GetIntensity();
 			if (ImGui::DragFloat("##Intensity", &intensity, 0.01f, 0.0f, 1.0f))
 			{
-				asSharedPointLight->SetIntensity(intensity);
+				asPointLight->SetIntensity(intensity);
 				modified = true;
 			}
 			ImGui::PopStyleVar();
 
 			ImGui::Text("Color"); ImGui::SameLine();
-			float3 color = asSharedPointLight->GetColor();
+			float3 color = asPointLight->GetColor();
 			if (ImGui::ColorEdit3("MyColor##1", (float*)&color))
 			{
-				asSharedPointLight->SetColor(color);
+				asPointLight->SetColor(color);
 				modified = true;
 			}
 
 			ImGui::Text("Radius"); ImGui::SameLine();
 			ImGui::SetNextItemWidth(80.0f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(5.0f, 1.0f));
-			float radius = asSharedPointLight->GetRadius();
+			float radius = asPointLight->GetRadius();
 			if (ImGui::DragFloat("##Radius", &radius, 0.01f, 0.0001f, std::numeric_limits<float>::max()))
 			{
-				asSharedPointLight->SetRadius(radius);
+				asPointLight->SetRadius(radius);
 				modified = true;
 			}
 

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentPointLight.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentPointLight.h
@@ -7,7 +7,7 @@ class ComponentPointLight;
 class WindowComponentPointLight : public ComponentWindow
 {
 public:
-	WindowComponentPointLight(const std::weak_ptr<ComponentPointLight>& component);
+	WindowComponentPointLight(ComponentPointLight* component);
 	~WindowComponentPointLight() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentSpotLight.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentSpotLight.cpp
@@ -7,7 +7,7 @@
 #include "DataModels/Components/ComponentSpotLight.h"
 #include "DataModels/Components/ComponentPointLight.h"
 
-WindowComponentSpotLight::WindowComponentSpotLight(const std::weak_ptr<ComponentSpotLight>& component) :
+WindowComponentSpotLight::WindowComponentSpotLight(ComponentSpotLight* component) :
 	ComponentWindow("SPOT LIGHT", component)
 {
 }
@@ -16,10 +16,9 @@ void WindowComponentSpotLight::DrawWindowContents()
 {
 	this->DrawEnableAndDeleteComponent();
 
-	std::shared_ptr<ComponentSpotLight> asSharedSpotLight =
-		std::dynamic_pointer_cast<ComponentSpotLight>(this->component.lock());
+	ComponentSpotLight* asSpotLight = static_cast<ComponentSpotLight*>(this->component);
 
-	if (asSharedSpotLight)
+	if (asSpotLight)
 	{
 		const char* lightTypes[] = { "Point", "Spot" };
 
@@ -45,14 +44,14 @@ void WindowComponentSpotLight::DrawWindowContents()
 						if (lightTypes[i] == "Point")
 						{
 							std::shared_ptr<ComponentPointLight> newPoint =
-								std::static_pointer_cast<ComponentPointLight>(asSharedSpotLight->GetOwner().lock()
+								std::static_pointer_cast<ComponentPointLight>(asSpotLight->GetOwner().lock()
 									->CreateComponentLight(LightType::POINT));
 
-							newPoint->SetColor(asSharedSpotLight->GetColor());
-							newPoint->SetIntensity(asSharedSpotLight->GetIntensity());
-							newPoint->SetRadius(asSharedSpotLight->GetRadius());
+							newPoint->SetColor(asSpotLight->GetColor());
+							newPoint->SetIntensity(asSpotLight->GetIntensity());
+							newPoint->SetRadius(asSpotLight->GetRadius());
 
-							asSharedSpotLight->GetOwner().lock()->RemoveComponent(asSharedSpotLight);
+							asSpotLight->GetOwner().lock()->RemoveComponent(asSpotLight->shared_from_this() /*this MUST be removed once Scene is updated*/);
 
 							App->scene->GetLoadedScene()->UpdateScenePointLights();
 							App->scene->GetLoadedScene()->RenderPointLights();
@@ -74,35 +73,35 @@ void WindowComponentSpotLight::DrawWindowContents()
 			ImGui::Text("Intensity"); ImGui::SameLine();
 			ImGui::SetNextItemWidth(80.0f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(5.0f, 1.0f));
-			float intensity = asSharedSpotLight->GetIntensity();
+			float intensity = asSpotLight->GetIntensity();
 			if (ImGui::DragFloat("##Intensity", &intensity, 0.01f, 0.0f, 1.0f))
 			{
-				asSharedSpotLight->SetIntensity(intensity);
+				asSpotLight->SetIntensity(intensity);
 				modified = true;
 			}
 			ImGui::PopStyleVar();
 
 			ImGui::Text("Color"); ImGui::SameLine();
-			float3 color = asSharedSpotLight->GetColor();
+			float3 color = asSpotLight->GetColor();
 			if (ImGui::ColorEdit3("MyColor##1", (float*)&color))
 			{
-				asSharedSpotLight->SetColor(color);
+				asSpotLight->SetColor(color);
 				modified = true;
 			}
 
 			ImGui::Text("Radius"); ImGui::SameLine();
 			ImGui::SetNextItemWidth(80.0f);
 			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(5.0f, 1.0f));
-			float radius = asSharedSpotLight->GetRadius();
+			float radius = asSpotLight->GetRadius();
 			if (ImGui::DragFloat("##Radius", &radius, 0.01f, 0.0001f, std::numeric_limits<float>::max()))
 			{
-				asSharedSpotLight->SetRadius(radius);
+				asSpotLight->SetRadius(radius);
 				modified = true;
 			}
 			ImGui::PopStyleVar();
 
-			float innerAngle = asSharedSpotLight->GetInnerAngle();
-			float outerAngle = asSharedSpotLight->GetOuterAngle();
+			float innerAngle = asSpotLight->GetInnerAngle();
+			float outerAngle = asSpotLight->GetOuterAngle();
 
 			ImGui::Text("Inner Angle"); ImGui::SameLine();
 			ImGui::SetNextItemWidth(80.0f);
@@ -111,7 +110,7 @@ void WindowComponentSpotLight::DrawWindowContents()
 			{
 				if (innerAngle <= outerAngle)
 				{
-					asSharedSpotLight->SetInnerAngle(innerAngle);
+					asSpotLight->SetInnerAngle(innerAngle);
 					modified = true;
 				}
 			}
@@ -124,7 +123,7 @@ void WindowComponentSpotLight::DrawWindowContents()
 			{
 				if (outerAngle >= innerAngle)
 				{
-					asSharedSpotLight->SetOuterAngle(outerAngle);
+					asSpotLight->SetOuterAngle(outerAngle);
 					modified = true;
 				}
 			}

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentSpotLight.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentSpotLight.h
@@ -7,7 +7,7 @@ class ComponentSpotLight;
 class WindowComponentSpotLight : public ComponentWindow
 {
 public:
-	WindowComponentSpotLight(const std::weak_ptr<ComponentSpotLight>& component);
+	WindowComponentSpotLight(ComponentSpotLight* component);
 	~WindowComponentSpotLight() override = default;
 
 protected:

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentTransform.cpp
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentTransform.cpp
@@ -8,21 +8,20 @@
 #include "DataModels/Components/ComponentTransform.h"
 #include "DataModels/Components/ComponentLight.h"
 
-WindowComponentTransform::WindowComponentTransform(const std::weak_ptr<ComponentTransform>& component) :
+WindowComponentTransform::WindowComponentTransform(ComponentTransform* component) :
 	ComponentWindow("TRANSFORM", component)
 {
 }
 
 void WindowComponentTransform::DrawWindowContents()
 {
-	std::shared_ptr<ComponentTransform> asSharedTransform =
-		std::dynamic_pointer_cast<ComponentTransform>(this->component.lock());
+	ComponentTransform* asTransform = static_cast<ComponentTransform*>(this->component);
 
-	if (asSharedTransform)
+	if (asTransform)
 	{
-		currentTranslation = asSharedTransform->GetPosition();
-		currentRotation = asSharedTransform->GetRotationXYZ();
-		currentScale = asSharedTransform->GetScale();
+		currentTranslation = asTransform->GetPosition();
+		currentRotation = asTransform->GetRotationXYZ();
+		currentScale = asTransform->GetScale();
 
 		currentDragSpeed = 0.025f;
 
@@ -30,7 +29,7 @@ void WindowComponentTransform::DrawWindowContents()
 		rotationModified = false;
 		scaleModified = false;
 
-		bool ownerIsRoot = App->scene->GetLoadedScene()->GetRoot() == asSharedTransform->GetOwner().lock();
+		bool ownerIsRoot = App->scene->GetLoadedScene()->GetRoot() == asTransform->GetOwner().lock();
 
 		// The root must not be moved through the inspector
 		if (ownerIsRoot)
@@ -40,9 +39,9 @@ void WindowComponentTransform::DrawWindowContents()
 
 		if (ownerIsRoot)
 		{
-			asSharedTransform->SetPosition(float3::zero);
-			asSharedTransform->SetRotation(Quat::identity);
-			asSharedTransform->SetScale(float3::one);
+			asTransform->SetPosition(float3::zero);
+			asTransform->SetRotation(Quat::identity);
+			asTransform->SetScale(float3::one);
 			return;
 		}
 
@@ -164,19 +163,18 @@ void WindowComponentTransform::DrawTransformTable()
 
 void WindowComponentTransform::UpdateComponentTransform()
 {
-	std::shared_ptr<ComponentTransform> asSharedTransform =
-		std::dynamic_pointer_cast<ComponentTransform>(this->component.lock());
+	ComponentTransform* asTransform = static_cast<ComponentTransform*>(this->component);
 
-	if (asSharedTransform)
+	if (asTransform)
 	{
 		if (translationModified)
 		{
-			asSharedTransform->SetPosition(currentTranslation);
+			asTransform->SetPosition(currentTranslation);
 		}
 
 		if (rotationModified)
 		{
-			asSharedTransform->SetRotation(currentRotation);
+			asTransform->SetRotation(currentRotation);
 		}
 
 		if (scaleModified)
@@ -185,30 +183,29 @@ void WindowComponentTransform::UpdateComponentTransform()
 			if (currentScale.y <= 0) currentScale.y = 0.0001f;
 			if (currentScale.z <= 0) currentScale.z = 0.0001f;
 
-			asSharedTransform->SetScale(currentScale);
+			asTransform->SetScale(currentScale);
 		}
 
-		asSharedTransform->CalculateLocalMatrix();
-		asSharedTransform->CalculateGlobalMatrix();
+		asTransform->CalculateLocalMatrix();
+		asTransform->CalculateGlobalMatrix();
 	}
 }
 
 void WindowComponentTransform::UpdateLights()
 {
-	std::shared_ptr<ComponentTransform> asSharedTransform =
-		std::dynamic_pointer_cast<ComponentTransform>(this->component.lock());
+	ComponentTransform* asTransform = static_cast<ComponentTransform*>(this->component);
 
-	if (asSharedTransform)
+	if (asTransform)
 	{
 		//Rendering lights if modified
 		if (translationModified || rotationModified)
 		{
-			std::shared_ptr<Component> comp = asSharedTransform->GetOwner().lock()->GetComponent(ComponentType::LIGHT);
+			std::shared_ptr<Component> comp = asTransform->GetOwner().lock()->GetComponent(ComponentType::LIGHT);
 			std::shared_ptr<ComponentLight> lightComp = std::static_pointer_cast<ComponentLight>(comp);
 
 			if (lightComp)
 			{
-				asSharedTransform->CalculateLightTransformed(lightComp, translationModified, rotationModified);
+				asTransform->CalculateLightTransformed(lightComp, translationModified, rotationModified);
 			}
 		}
 	}

--- a/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentTransform.h
+++ b/Source/DataModels/Windows/SubWindows/ComponentWindows/WindowComponentTransform.h
@@ -9,7 +9,7 @@ class ComponentTransform;
 class WindowComponentTransform : public ComponentWindow
 {
 public:
-	WindowComponentTransform(const std::weak_ptr<ComponentTransform>& component);
+	WindowComponentTransform(ComponentTransform* component);
 	~WindowComponentTransform() override = default;
 
 protected:

--- a/Source/DataModels/Windows/WindowMainMenu.cpp
+++ b/Source/DataModels/Windows/WindowMainMenu.cpp
@@ -6,12 +6,12 @@
 const std::string WindowMainMenu::repositoryLink = "https://github.com/Pre-SuperAwesomeEngine/Engine";
 bool WindowMainMenu::defaultEnabled = true;
 
-WindowMainMenu::WindowMainMenu(const std::vector< std::shared_ptr<EditorWindow> >& editorWindows) : Window("Main Menu")
+WindowMainMenu::WindowMainMenu(const std::vector< std::unique_ptr<EditorWindow> >& editorWindows) : Window("Main Menu")
 {
 	about = std::make_unique<WindowAbout>();
 	
 	nWindows = editorWindows.size();
-	for (std::shared_ptr<EditorWindow> window : editorWindows)
+	for (const std::unique_ptr<EditorWindow>& window : editorWindows)
 	{
 		windowNames.push_back(window->GetName());
 		windowsEnabled.push_back(true);

--- a/Source/DataModels/Windows/WindowMainMenu.cpp
+++ b/Source/DataModels/Windows/WindowMainMenu.cpp
@@ -10,11 +10,10 @@ WindowMainMenu::WindowMainMenu(const std::vector< std::unique_ptr<EditorWindow> 
 {
 	about = std::make_unique<WindowAbout>();
 	
-	nWindows = editorWindows.size();
 	for (const std::unique_ptr<EditorWindow>& window : editorWindows)
 	{
-		windowNames.push_back(window->GetName());
-		windowsEnabled.push_back(true);
+		std::pair<std::string, bool> windowNameAndEnabled = std::make_pair(window->GetName(), true);
+		windowNamesAndEnabled.push_back(windowNameAndEnabled);
 	}
 }
 
@@ -39,11 +38,9 @@ void WindowMainMenu::DrawWindowsMenu()
 {
 	if (ImGui::BeginMenu("Windows"))
 	{
-		for (int i = 0; i < nWindows; ++i)
+		for (std::pair<std::string, bool>& windowNameAndEnabled : windowNamesAndEnabled)
 		{
-			bool windowEnabled = IsWindowEnabled(i);
-			ImGui::MenuItem(windowNames[i].c_str(), NULL, &windowEnabled);
-			SetWindowEnabled(i, windowEnabled);
+			ImGui::MenuItem(windowNameAndEnabled.first.c_str(), NULL, &windowNameAndEnabled.second);
 		}
 		ImGui::EndMenu();
 	}

--- a/Source/DataModels/Windows/WindowMainMenu.h
+++ b/Source/DataModels/Windows/WindowMainMenu.h
@@ -31,17 +31,15 @@ private:
 	
 	bool showAbout = false;
 	
-	size_t nWindows;
-	std::vector<std::string> windowNames;
-	std::vector<bool> windowsEnabled;
+	std::vector<std::pair<std::string, bool> > windowNamesAndEnabled;
 };
 
 inline bool WindowMainMenu::IsWindowEnabled(int windowIndex) const
 {
-	return windowsEnabled[windowIndex];
+	return windowNamesAndEnabled[windowIndex].second;
 }
 
 inline void WindowMainMenu::SetWindowEnabled(int windowIndex, bool enabled)
 {
-	windowsEnabled[windowIndex] = enabled;
+	windowNamesAndEnabled[windowIndex].second = enabled;
 }

--- a/Source/DataModels/Windows/WindowMainMenu.h
+++ b/Source/DataModels/Windows/WindowMainMenu.h
@@ -8,7 +8,7 @@
 class WindowMainMenu : public Window
 {
 public:
-	WindowMainMenu(const std::vector<std::shared_ptr<EditorWindow> >& editorWindows);
+	WindowMainMenu(const std::vector<std::unique_ptr<EditorWindow> >& editorWindows);
 	~WindowMainMenu();
 
 	static const std::string repositoryLink;

--- a/Source/Modules/ModuleEditor.cpp
+++ b/Source/Modules/ModuleEditor.cpp
@@ -45,13 +45,13 @@ bool ModuleEditor::Init()
 	ImFontConfig icons_config; icons_config.MergeMode = true; icons_config.PixelSnapH = true;
 	io.Fonts->AddFontFromMemoryCompressedBase85TTF(FONT_ICON_BUFFER_NAME_IGFD, 15.0f, &icons_config, icons_ranges);
 
-	windows.push_back(scene = std::make_shared<WindowScene>());
-	windows.push_back(std::make_shared<WindowConfiguration>());
-	windows.push_back(std::make_shared<WindowInspector>());
-	windows.push_back(std::make_shared<WindowHierarchy>());
-	windows.push_back(std::make_shared<WindowEditorControl>());
-	windows.push_back(std::make_shared<WindowFileBrowser>());
-	windows.push_back(std::make_shared<WindowConsole>());
+	windows.push_back(std::unique_ptr<WindowScene>(scene = new WindowScene()));
+	windows.push_back(std::make_unique<WindowConfiguration>());
+	windows.push_back(std::make_unique<WindowInspector>());
+	windows.push_back(std::make_unique<WindowHierarchy>());
+	windows.push_back(std::make_unique<WindowEditorControl>());
+	windows.push_back(std::make_unique<WindowFileBrowser>());
+	windows.push_back(std::make_unique<WindowConsole>());
 	mainMenu = std::make_unique<WindowMainMenu>(windows);
 
 	return true;
@@ -71,7 +71,6 @@ bool ModuleEditor::CleanUp()
 	ImGui_ImplSDL2_Shutdown();
 	ImGui::DestroyContext();
 
-	lines.clear();
 	windows.clear();
 
 	return true;

--- a/Source/Modules/ModuleEditor.h
+++ b/Source/Modules/ModuleEditor.h
@@ -21,20 +21,19 @@ public:
 
 	void Resized();
 
-	const std::shared_ptr<WindowScene> GetScene() const;
+	const WindowScene* GetScene() const;
 
 	bool IsSceneFocused() const;
 
 private:
-	std::vector<std::string> lines;
-	std::vector<std::shared_ptr<EditorWindow> > windows;
+	std::vector<std::unique_ptr<EditorWindow> > windows;
 	std::unique_ptr<WindowMainMenu> mainMenu = nullptr;
-	std::shared_ptr<WindowScene> scene = nullptr;
+	WindowScene* scene = nullptr;
 
 	bool windowResized = false;
 };
 
-inline const std::shared_ptr<WindowScene> ModuleEditor::GetScene() const
+inline const WindowScene* ModuleEditor::GetScene() const
 {
 	return scene;
 }

--- a/Source/Modules/ModuleEngineCamera.cpp
+++ b/Source/Modules/ModuleEngineCamera.cpp
@@ -88,7 +88,7 @@ update_status ModuleEngineCamera::Update()
 		if (App->input->GetMouseButton(SDL_BUTTON_LEFT) != KeyState::IDLE 
 			&& App->input->GetKey(SDL_SCANCODE_LALT) == KeyState::IDLE)
 		{
-			std::shared_ptr<WindowScene> windowScene = std::static_pointer_cast<WindowScene>(App->editor->GetScene());
+			const WindowScene* windowScene = App->editor->GetScene();
 			LineSegment ray = CreateRaycastFromMousePosition(windowScene);
 			CalculateHittedGameObjects(ray);
 		}
@@ -546,7 +546,7 @@ int ModuleEngineCamera::GetFrustumMode() const
 	return frustumMode;
 }
 
-LineSegment ModuleEngineCamera::CreateRaycastFromMousePosition(std::shared_ptr<WindowScene> windowScene)
+LineSegment ModuleEngineCamera::CreateRaycastFromMousePosition(const WindowScene* windowScene)
 {
 	// normalize the input to [-1, 1].
 	ImVec2 startPosScene = windowScene->GetStartPos();

--- a/Source/Modules/ModuleEngineCamera.h
+++ b/Source/Modules/ModuleEngineCamera.h
@@ -98,7 +98,7 @@ public:
 	const float3& GetPosition() const;
 	
 private:
-	LineSegment CreateRaycastFromMousePosition(std::shared_ptr<WindowScene> windowScene);
+	LineSegment CreateRaycastFromMousePosition(const WindowScene* windowScene);
 	
 	void CalculateHittedGameObjects(const LineSegment& ray);
 	void SetNewSelectedGameObject(const std::map<float, std::weak_ptr<GameObject>>& hittedGameObjects,

--- a/Source/Modules/ModuleInput.h
+++ b/Source/Modules/ModuleInput.h
@@ -34,8 +34,6 @@ public:
 	bool IsMouseWheelScrolled() const;
 
 private:
-	const uint8_t* keyboard = NULL;
-
 	KeyState keysState[SDL_NUM_SCANCODES] = { KeyState::IDLE };
 	KeyState mouseButtonState[NUM_MOUSEBUTTONS] = { KeyState::IDLE };
 

--- a/Source/Modules/ModuleRender.cpp
+++ b/Source/Modules/ModuleRender.cpp
@@ -166,7 +166,7 @@ bool ModuleRender::Start()
 	std::shared_ptr<ResourceSkyBox> resourceSkybox = std::dynamic_pointer_cast<ResourceSkyBox>(App->resources->RequestResource(skyboxUID).lock());
 	if (resourceSkybox)
 	{
-		skybox = std::make_shared<Skybox>(resourceSkybox);
+		skybox = std::make_unique<Skybox>(resourceSkybox);
 	}
 	return true;
 }
@@ -196,7 +196,6 @@ update_status ModuleRender::Update()
 	if (skybox)
 	{
 		skybox->Draw();
-
 	}
 
 	FillRenderList(App->scene->GetLoadedScene()->GetSceneQuadTree());

--- a/Source/Modules/ModuleRender.h
+++ b/Source/Modules/ModuleRender.h
@@ -56,7 +56,8 @@ private:
 	std::vector<std::weak_ptr<GameObject> > gameObjectsToDraw;
 	const std::vector<std::string> modelTypes = { "FBX" };
 
-	std::shared_ptr<Skybox> skybox;
+	//should this be here?
+	std::unique_ptr<Skybox> skybox;
 
 	GLuint frameBuffer = 0;
 	GLuint renderedTexture = 0;


### PR DESCRIPTION
I have removed all of the uses of shared pointers in those classes where it was trivial to do so. If I didn't miss any of those cases, the only places in the engine where they remain are the Quadtree class, the ModuleProgram and Program classes, and the ModuleScene, Scene, GameObject and Component classes, pending a more supervised refactor.